### PR TITLE
Update header links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -88,6 +88,12 @@ header.shrink .header-wrapper {
     color: var(--primary);
 }
 
+/* ссылка-логотип */
+.logo a {
+    text-decoration: none;
+    color: inherit;
+}
+
 .menu {
     list-style: none;
     margin: 0;
@@ -501,23 +507,3 @@ details summary {
     margin-top: 0;
 }
 
-/* кнопка Домой для страницы тура */
-.home-btn {
-    position: fixed;
-    bottom: 1.5em;
-    right: 1.5em;
-    background-color: var(--accent);
-    color: #fff;
-    border-radius: 50%;
-    width: 2.5em;
-    height: 2.5em;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.home-btn svg {
-    width: 1.4em;
-    height: 1.4em;
-    fill: currentColor;
-}

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
     <header>
         <div class="container header-wrapper">
-            <h1 class="logo">MandarinWays</h1>
+            <h1 class="logo"><a href="index.html">MandarinWays</a></h1>
             <button id="menu-toggle" class="menu-toggle" aria-label="Открыть меню">☰</button>
             <nav class="main-nav">
                 <ul class="menu">

--- a/tour.html
+++ b/tour.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <div class="container header-wrapper">
-      <h1 class="logo">MandarinWays</h1>
+      <h1 class="logo"><a href="index.html">MandarinWays</a></h1>
       <div class="messenger-links">
         <a href="https://t.me/mandarinways" class="messenger-icon" aria-label="Telegram">
           <svg viewBox="0 0 24 24"><path d="M22 2L2 11l5 2 2 6 3-4 5 4z"/></svg>
@@ -25,11 +25,6 @@
     <div class="container hero-inner">
       <h2 id="hero-title"></h2>
       <p id="hero-subtitle"></p>
-      <a href="index.html" class="home-btn fixed-cta" aria-label="На главную">
-        <svg viewBox="0 0 24 24">
-          <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
-        </svg>
-      </a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- make the site logo a link back to home on every page
- remove the floating home icon from the tour page
- clean up unused CSS for the removed button

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685000902464833091fc75bb0edc449d